### PR TITLE
chore(build): 更新项目版本号并配置测试模块部署跳过

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,10 @@ SIP Proxy is a GB28181-2016 communication framework built on Java 17 and Spring 
 
 It is delivered as a **Maven library**, not a standalone service. Business systems (typically a `sip-gateway` layer the user implements on top) embed it in-process and interact via Spring Events (inbound) and `CommandSender` beans (outbound). A single JVM can act as platform server (`gb28181-server`) and device client (`gb28181-client`) simultaneously for cascading scenarios.
 
-Current version: **1.5.0** (see `CHANGELOG.md` for breaking changes vs 1.4.x; v1.5.0 删除 4 个 client 业务接口 + 10 个旧 client 事件，新增 listener 化业务 API。详见 [doc/LISTENER-LAYERED-DESIGN.md](doc/LISTENER-LAYERED-DESIGN.md) 与 [doc/LISTENER-MIGRATION-GUIDE.md](doc/LISTENER-MIGRATION-GUIDE.md))。
+Current version: **1.7.0** (see `CHANGELOG.md`). Recent breaking changes worth knowing before touching outbound code:
+
+- **1.7.0** — Outbound dialog rewrite. `BYE` and `SUBSCRIBE` refresh/unsubscribe are now dialog-aware: `ServerCommandSender.deviceBye(callId)` (deviceId removed), `ClientCommandSender.sendByeCommand(callId)`, `SipSender.doByeRequest(callId)` (old `(FromDevice, ToDevice)` overload **deleted**, not deprecated). Calls without an established dialog throw `DialogNotFoundException` instead of getting a silent `481`. New `DialogRegistry` + `DialogRegistryCleaner` are core to INVITE/SUBSCRIBE flows. See [doc/OUTBOUND-DIALOG-PLAN.md](doc/OUTBOUND-DIALOG-PLAN.md).
+- **1.5.0** — Listener-layered API. Removed 4 client business handler interfaces + 10 old client events; added `QueryListener` / `ControlListener` / `ConfigListener` / `SubscribeListener` / `NotifyListener` (client) and `DeviceResponseListener` / `DeviceNotifyListener` / `DeviceLifecycleListener` / `DeviceSessionListener` (server). See [doc/LISTENER-LAYERED-DESIGN.md](doc/LISTENER-LAYERED-DESIGN.md) and [doc/LISTENER-MIGRATION-GUIDE.md](doc/LISTENER-MIGRATION-GUIDE.md).
 
 ## Build and Development Commands
 
@@ -63,6 +66,17 @@ SIP Message
 ### Outbound Commands
 
 - **`ClientCommandSender`** / **`ServerCommandSender`** — strategy-pattern command senders for outbound SIP messages. `ServerCommandSender` requires `DeviceSessionCache` to look up device sessions.
+
+### Dialog-Aware Outbound (1.7.0+)
+
+INVITE and SUBSCRIBE go through **stateful** transmission (`SipMessageTransmitter.transmitStateful` / `transmitStatefulPreRegister`), which uses a `ClientTransaction` so JAIN-SIP auto-creates a `Dialog`. The dialog is recorded in `DialogRegistry` (in-process, keyed by `callId`, with `kind=INVITE|SUBSCRIBE` and `expiresAtMs`).
+
+- **BYE** must reference an existing dialog: `deviceBye(callId)` / `sendByeCommand(callId)` / `doByeRequest(callId)`. No dialog → `DialogNotFoundException`. Dialog cleanup: `AbstractSipListener.processDialogTerminated` → `DialogRegistry.remove` (INVITE primary path).
+- **SUBSCRIBE refresh / unsubscribe** must also be dialog-aware: `refreshSubscribe(callId, expires)` / `unsubscribe(callId)` on both senders, plus `SipSender.doSubscribeRefresh(callId, content, expires)` and `CommandContext.forSubscribeRefresh(...)`.
+- **`DialogRegistryCleaner`** (`@Scheduled` 60s) sweeps expired SUBSCRIBE entries because RFC 6665 §4.4.1 case 3 has no `DialogTerminatedEvent`.
+- **INVITE 200 OK ACK** uses `dialog.sendAck` (see `InviteResponseProcessor.sendAck`), symmetric with BYE.
+
+**Implication for new outbound logic:** if you're adding any in-dialog request (re-INVITE, UPDATE, INFO, NOTIFY-from-server, etc.), use the stateful path and look up the dialog from `DialogRegistry` — never construct a fresh `From`/`To` pair without the to-tag.
 
 ### Event Bus & Listener API
 
@@ -169,4 +183,6 @@ Key docs in `doc/` (consult before non-trivial changes):
 - `PROTOCOL-DECOUPLING-PLAN.md` — sip-common / gb28181-common boundary rules (1.3.0)
 - `BREAKING-CHANGE-REMOVE-HANDLER-INTERFACE.md` — 1.3.0 removal of `*Handler` interfaces in favor of pure Spring Events
 - `INVITE-REFACTOR-PLAN.md` — INVITE async refactor (1.3.0)
+- `LISTENER-LAYERED-DESIGN.md` / `LISTENER-MIGRATION-GUIDE.md` — 1.5.0 listener API (canonical for new business code)
+- `OUTBOUND-DIALOG-PLAN.md` — 1.7.0 dialog-aware BYE / SUBSCRIBE refresh (canonical for outbound flows)
 - `GB28181-2016.md` / `GBT-28181-2022.md` — protocol references

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/badge/MIT_License-blue.svg)](https://raw.githubusercontent.com/lunasaw/gb28181-proxy/master/LICENSE)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.3.1-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Java](https://img.shields.io/badge/Java-17-orange.svg)](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
-[![Version](https://img.shields.io/badge/version-1.5.x-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)](CHANGELOG.md)
 
 [项目文档](https://lunasaw.github.io/gb28181-proxy/) | [问题反馈](https://github.com/lunasaw/gb28181-proxy/issues) | [CHANGELOG](CHANGELOG.md)
 
@@ -12,7 +12,11 @@
 
 **核心定位**：纯协议层框架，屏蔽 SIP 协议细节。业务方实现 [Listener 接口](#二listener-接口业务方主入口)（推荐）或监听 [Layer 1 协议事件](#三layer-1-协议事件跨切层) 接收消息，通过 `ClientCommandSender` / `ServerCommandSender` 发送命令，**不直接接触 JAIN-SIP**。框架内置 GB28181-2016 + GB/T 28181-2022 协议实现，单 JVM 可同时启用平台服务端（`gb28181-server`）和设备客户端（`gb28181-client`），支持级联代理场景。
 
-> **1.5.x 架构主线**：业务接口完全 listener 化（client 5 个 listener + server 4 个 listener，全部默认方法、按需 override）；server 端 32 个 `Device*Event` 已收敛为 4 个 `Server*Event` + 强类型 payload；client 端 4 个旧 `*Handler` 接口与 10 个细粒度 query/config event 已删除；GB/T 28181-2022 命令集（设备升级、抓拍、PTZ 精准、SD 卡、看守位、巡航轨迹、目标跟踪、报警订阅、语音对讲、视频下载等）全量落地。详见 [CHANGELOG.md](CHANGELOG.md)、[doc/LISTENER-LAYERED-DESIGN.md](doc/LISTENER-LAYERED-DESIGN.md) 与 [doc/PROTOCOL-LAYERING-MATRIX.md](doc/PROTOCOL-LAYERING-MATRIX.md)。
+> **架构主线**：
+> - **1.7.0 — 出站 Dialog 维护**：BYE / SUBSCRIBE 续订 / 退订改为 dialog-aware。`ServerCommandSender.deviceBye(deviceId, callId)` → `deviceBye(callId)`，`ClientCommandSender.sendByeCommand(FromDevice, ToDevice)` → `sendByeCommand(callId)`，`SipSender.doByeRequest(FromDevice, ToDevice)` **直接删除**改 `doByeRequest(callId)`。无 dialog 时抛 `DialogNotFoundException` 而非吞 `481`。新增进程内 `DialogRegistry` + `DialogRegistryCleaner`，INVITE / SUBSCRIBE 改走 stateful 发送，自动建立 JAIN-SIP Dialog；新增 `refreshSubscribe(callId, ...)` / `unsubscribe(callId)` API 替代历史"重发 SUBSCRIBE"做法。详见 [doc/OUTBOUND-DIALOG-PLAN.md](doc/OUTBOUND-DIALOG-PLAN.md)。
+> - **1.5.x — Listener 化业务接口**：业务接口完全 listener 化（client 5 个 listener + server 4 个 listener，全部默认方法、按需 override）；server 端 32 个 `Device*Event` 已收敛为 4 个 `Server*Event` + 强类型 payload；client 端 4 个旧 `*Handler` 接口与 10 个细粒度 query/config event 已删除；GB/T 28181-2022 命令集（设备升级、抓拍、PTZ 精准、SD 卡、看守位、巡航轨迹、目标跟踪、报警订阅、语音对讲、视频下载等）全量落地。详见 [doc/LISTENER-LAYERED-DESIGN.md](doc/LISTENER-LAYERED-DESIGN.md) 与 [doc/PROTOCOL-LAYERING-MATRIX.md](doc/PROTOCOL-LAYERING-MATRIX.md)。
+>
+> 完整版本历史见 [CHANGELOG.md](CHANGELOG.md)。
 
 ## 模块结构
 
@@ -86,14 +90,14 @@ sip-proxy 不是独立服务，而是嵌入到业务方实现的 **sip-gateway**
 <dependency>
     <groupId>io.github.lunasaw</groupId>
     <artifactId>gb28181-server</artifactId>
-    <version>1.5.x</version>
+    <version>1.7.0</version>
 </dependency>
 
 <!-- 设备客户端 -->
 <dependency>
     <groupId>io.github.lunasaw</groupId>
     <artifactId>gb28181-client</artifactId>
-    <version>1.5.x</version>
+    <version>1.7.0</version>
 </dependency>
 ```
 
@@ -150,7 +154,7 @@ sip:
 
 ## 业务接入：三层架构
 
-sip-proxy v1.5.x 把入站消息处理拆成三层，业务方主入口在 **L2 Listener 接口**，跨切层走 **L1 Layer 1 协议事件**：
+sip-proxy 把入站消息处理拆成三层（listener 三层模型自 v1.5.0 起作为主线），业务方主入口在 **L2 Listener 接口**，跨切层走 **L1 Layer 1 协议事件**：
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -323,19 +327,58 @@ String callId = serverCommandSender.deviceInvitePlayBack(deviceId, mediaIp, medi
 String callId = serverCommandSender.deviceInviteTalk(deviceId, mediaIp, mediaPort, StreamModeEnum.UDP);
 String callId = serverCommandSender.deviceInviteDownload(deviceId, mediaIp, mediaPort, startMs, endMs, downloadSpeed, StreamModeEnum.UDP);
 String callId = serverCommandSender.deviceInvitePlayBackControl(deviceId, PlayActionEnums.PAUSE);
-String callId = serverCommandSender.deviceBye(deviceId, originalCallId);
+serverCommandSender.deviceBye(callId);   // 1.7.0+：dialog-aware，必须先 INVITE 200 OK
+
+// SUBSCRIBE 续订 / 退订（1.7.0+，dialog-aware）
+serverCommandSender.refreshSubscribe(callId, 3600);              // Catalog/PTZPosition：保留原 SubscribeContent
+serverCommandSender.refreshSubscribe(callId, content, 3600);     // MobilePosition/Alarm：附携新 content（如新 Interval）
+serverCommandSender.unsubscribe(callId);                          // Expires=0，等价退订
 
 // 语音广播（§9.12.1）
 String callId = serverCommandSender.deviceBroadcast(deviceId);
 ```
 
 > v1.5.1 起 `ServerCommandSender` 31 个 `@Deprecated` 静态门面方法已删除，业务侧需注入 bean 调用同名实例方法。
+>
+> v1.7.0 起 `deviceBye(deviceId, callId)` 改为 `deviceBye(callId)`、`SipSender.doByeRequest(FromDevice, ToDevice)` 直接删除。详见下文「Dialog-Aware 出站」与 [doc/OUTBOUND-DIALOG-PLAN.md](doc/OUTBOUND-DIALOG-PLAN.md)。
 
 #### `ClientCommandSender`（设备 → 平台）
 
 设备侧主动上报与应答（注册、心跳、Catalog 通知、报警上报、抓拍完成通知、升级结果通知、视频上传通知等）。绝大部分查询应答由 `ClientListenerAdapter` 在 `QueryListener` 返回非 null 时自动调用，业务方一般无需直接接触。
 
-### 四、INVITE 异步回包模型（设备主动 INVITE）
+### 四、Dialog-Aware 出站（v1.7.0+）
+
+INVITE 与 SUBSCRIBE 走 **stateful 发送**（`SipMessageTransmitter.transmitStateful` / `transmitStatefulPreRegister`），通过 `ClientTransaction` 让 JAIN-SIP 自动建立 `Dialog`，同时记录到进程内 `DialogRegistry`（按 `callId` 索引，含 `kind=INVITE|SUBSCRIBE` 与 `expiresAtMs`）。
+
+**约束**：
+
+- **BYE 必须有已建立的 dialog**：`deviceBye(callId)` / `sendByeCommand(callId)` / `doByeRequest(callId)`。无 dialog 则抛 `DialogNotFoundException`，**不会被设备 `481` 静默吞掉**。
+- **SUBSCRIBE 续订 / 退订必须 dialog-aware**：业务方调 `refreshSubscribe(callId, expires)` / `unsubscribe(callId)`，**禁止历史"重发新 SUBSCRIBE"做法**——会在设备侧产生孤儿订阅持续浪费带宽。
+- **INVITE 200 OK 的 ACK** 改用 `dialog.sendAck`（见 `InviteResponseProcessor.sendAck`），与 BYE 路径对称。
+
+**Dialog 清理路径**：
+
+| 场景 | 触发方式 | 路径 |
+|------|---------|------|
+| INVITE 主���径（BYE 后） | JAIN-SIP `DialogTerminatedEvent` | `AbstractSipListener.processDialogTerminated` → `DialogRegistry.remove` |
+| SUBSCRIBE 自然过期 | 兜底定时清理（RFC 6665 §4.4.1 case 3 无 `DialogTerminatedEvent`） | `DialogRegistryCleaner` `@Scheduled` 60s 跑一次 |
+
+**业务侧调用模板**：
+
+```java
+try {
+    commandSender.deviceBye(callId);
+} catch (DialogNotFoundException e) {
+    // dialog 已不存在（对端先发 BYE / INVITE 还未 200 OK / callId 错误）
+    log.warn("BYE 失败：dialog 不存在 callId={}", callId, e);
+}
+```
+
+**为什么需要先 deprecated 桥接的形式被否决**：旧 BYE API（`deviceBye(deviceId, callId)`）会构造缺 to-tag 的 `From`/`To`，设备直接返回 `481 Call leg/Transaction does not exist`，长期被静默吞掉。1.7.0 选择**直接删除**让编译期一次性暴露所有调用点，强制业务侧迁移到 dialog-aware 路径。
+
+> ⚠️ **新增任何 in-dialog 出站请求**（re-INVITE、UPDATE、INFO、server-side NOTIFY 等）必须走 stateful path 并从 `DialogRegistry` 取出 dialog，**不要**自己拼 `From`/`To` 头。
+
+### 五、INVITE 异步回包模型（设备主动 INVITE）
 
 设备主动发起的 INVITE（如语音对讲）需要业务方准备 SDP，框架采用**两步异步**模型：
 
@@ -359,7 +402,7 @@ String callId = serverCommandSender.deviceBroadcast(deviceId);
 
 > ⚠️ **设备 Timer B 限制**：即使框架侧 `extendContext` 续期到 90 秒，设备侧（INVITE 客户端）按 RFC 3261 §17.1.1.2 在 `Timer B = 64*T1 = 32s` 后会放弃事务。业务处理时间应控制在 **30s 内直接回包**；30~60s 需主动发 `180 Ringing` + `extendContext`；> 60s 改为先回 200 OK + 占位 SDP，后续走 re-INVITE。详见 [doc/LAYERED-ARCHITECTURE.md §7](doc/LAYERED-ARCHITECTURE.md)。
 
-### 五、协议层扩展点（进阶）
+### 六、协议层扩展点（进阶）
 
 业务方一般只需实现 `DeviceSessionCache` / `*DeviceSupplier` + listener。少数高级场景才需要扩展协议层：
 
@@ -393,6 +436,7 @@ SIP Message
 | 状态类型 | 存储位置 | 说明 |
 |---------|---------|------|
 | `ServerTransaction` / `SipTransactionRegistry` | **进程内**（不可外化） | JAIN-SIP 实现类不可序列化、持有 socket 引用；同设备消息必须打同节点 |
+| `DialogRegistry`（出站 dialog 注册表，1.7.0+） | **进程内**（不可外化） | 持有 JAIN-SIP `Dialog` 引用，BYE / SUBSCRIBE refresh 必须打到原 INVITE / SUBSCRIBE 所在节点；与 SIP 事务状态同生命周期 |
 | `DeviceSessionCache`（设备注册信息） | **Redis**（共享，需高可用） | 业务方实现，节点间共享，节点故障后新节点可接管 |
 | `ServerDeviceSupplier`（设备信息） | **Redis**（共享，需高可用） | 业务方实现，读 Redis |
 | 设备订阅状态 | 业务方自管（client 端协议层 `SubscribeRegistry` 内化） | 框架 1.3.0 已删除全局 `SubscribeHolder`；client 端 SUBSCRIBE 200 OK 由 `SubscribeRegistry.put()` 内部维护 |
@@ -423,6 +467,7 @@ SIP Message
 3. 配置 `external-ip` 为 VIP，确保 SIP 包内 `Via` / `Contact` 头是集群可达地址
 4. 实现 `InviteContextStore`（参考 [`InMemoryInviteContextStore`](gb28181-test/src/main/java/io/github/lunasaw/gbproxy/test/gateway/InMemoryInviteContextStore.java) 改 Redis 版），处理 INVITE 异步回包跨节点路由
 5. 装配 `nodeAddressMap` Bean（K8s Endpoints / Nacos / Consul），将 `nodeId` 映射到内网地址
+6. **保证 BYE / SUBSCRIBE refresh 路由到原节点**：`DialogRegistry` 进程内持有 dialog，VIP 源 IP 哈希已能保证设备主动 BYE 落到原节点；业务方主动调 `deviceBye(callId)` / `refreshSubscribe(callId, ...)` 时，需在 sip-gateway HTTP 入口校验当前节点是否持有该 callId 的 dialog（同 INVITE 路由表，复用 `InviteContextStore` 的 `{nodeId}` 映射），否则转发到目标节点
 
 ## 构建与测试
 
@@ -484,6 +529,7 @@ bash scripts/check-sip-common-purity.sh
 
 | 文档 | 内容 |
 |------|------|
+| [OUTBOUND-DIALOG-PLAN.md](doc/OUTBOUND-DIALOG-PLAN.md) | 出站 Dialog 维护方案（v1.7.0 主干，BYE / SUBSCRIBE refresh dialog-aware） |
 | [LISTENER-LAYERED-DESIGN.md](doc/LISTENER-LAYERED-DESIGN.md) | Listener 化业务接口分层设计（v1.5.0 主干） |
 | [LISTENER-MIGRATION-GUIDE.md](doc/LISTENER-MIGRATION-GUIDE.md) | v1.4.0 → v1.5.0 业务侧迁移指南 |
 | [PROTOCOL-LAYERING-MATRIX.md](doc/PROTOCOL-LAYERING-MATRIX.md) | L0/L1/L2 三层协议栈逐 cmdType 落地矩阵（v1.5.6 基于代码事实） |

--- a/gb28181-client/pom.xml
+++ b/gb28181-client/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.2</version>
     </parent>
 
-    <version>1.7.0</version>
+    <version>1.7.2</version>
     <artifactId>gb28181-client</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-client</name>

--- a/gb28181-common/pom.xml
+++ b/gb28181-common/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.2</version>
     </parent>
 
-    <version>1.7.0</version>
+    <version>1.7.2</version>
     <artifactId>gb28181-common</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-common</name>

--- a/gb28181-server/pom.xml
+++ b/gb28181-server/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.2</version>
     </parent>
 
-    <version>1.7.0</version>
+    <version>1.7.2</version>
     <artifactId>gb28181-server</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-server</name>

--- a/gb28181-test/pom.xml
+++ b/gb28181-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.2</version>
     </parent>
 
     <version>${gb28181-proxy.version}</version>
@@ -181,6 +181,19 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!--
+                gb28181-test 是测试/示例模块（spring-boot repackage 打 fat jar），
+                不发布到 Maven Central。nexus-staging-maven-plugin 不认 maven-deploy-plugin 的 skip，
+                必须用自己的 skipNexusStagingDeployMojo 单独关闭。
+            -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.7.0</version>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
             <!--

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.lunasaw</groupId>
     <artifactId>sip-proxy</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.2</version>
     <packaging>pom</packaging>
     <modules>
         <module>sip-common</module>
@@ -28,8 +28,8 @@
         <app.profiles>${project.name}</app.profiles>
         <sip.version>1.3.0-91</sip.version>
         <dom4j.version>2.1.4</dom4j.version>
-        <sip-proxy-common.version>1.7.0</sip-proxy-common.version>
-        <gb28181-proxy.version>1.7.0</gb28181-proxy.version>
+        <sip-proxy-common.version>1.7.2</sip-proxy-common.version>
+        <gb28181-proxy.version>1.7.2</gb28181-proxy.version>
         <skywalking.version>9.1.0</skywalking.version>
         <guava.version>32.1.3-jre</guava.version>
         <caffeine.version>3.1.8</caffeine.version>

--- a/sip-common/pom.xml
+++ b/sip-common/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.2</version>
     </parent>
 
     <packaging>jar</packaging>
-    <version>1.7.0</version>
+    <version>1.7.2</version>
     <artifactId>sip-common</artifactId>
     <name>sip-common</name>
     <description>轻量级SIP框架封装</description>


### PR DESCRIPTION
- 将父项目及所有子模块版本从 1.7.0 升级至 1.7.2
- 在 gb28181-test 模块中添加 nexus-staging-maven-plugin 配置
- 配置 skipNexusStagingDeployMojo 以跳过测试模块的 Nexus 部署
- 更新依赖版本变量 sip-proxy-common.version 和 gb28181-proxy.version 至 1.7.2