### PR TITLE
release 1.8.2: 实时点播 INVITE 标准寻址 + 客户端重构

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.lunasaw</groupId>
     <artifactId>sip-proxy</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <packaging>pom</packaging>
     <modules>
         <module>sip-common</module>
@@ -27,8 +27,8 @@
         <app.profiles>${project.name}</app.profiles>
         <sip.version>1.3.0-91</sip.version>
         <dom4j.version>2.1.4</dom4j.version>
-        <sip-proxy-common.version>1.8.1</sip-proxy-common.version>
-        <gb28181-proxy.version>1.8.1</gb28181-proxy.version>
+        <sip-proxy-common.version>1.8.2</sip-proxy-common.version>
+        <gb28181-proxy.version>1.8.2</gb28181-proxy.version>
         <skywalking.version>9.1.0</skywalking.version>
         <guava.version>32.1.3-jre</guava.version>
         <caffeine.version>3.1.8</caffeine.version>

--- a/sip-common/pom.xml
+++ b/sip-common/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <packaging>jar</packaging>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <artifactId>sip-common</artifactId>
     <name>sip-common</name>
     <description>轻量级SIP框架封装</description>

--- a/sip-gateway/gateway-core/pom.xml
+++ b/sip-gateway/gateway-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>gateway-core</artifactId>

--- a/sip-gateway/gateway-gb28181/pom.xml
+++ b/sip-gateway/gateway-gb28181/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>gateway-gb28181</artifactId>

--- a/sip-gateway/gateway-gb28181/src/main/java/io/github/lunasaw/sipgateway/gb28181/handler/Gb28181WhitelistHandlers.java
+++ b/sip-gateway/gateway-gb28181/src/main/java/io/github/lunasaw/sipgateway/gb28181/handler/Gb28181WhitelistHandlers.java
@@ -186,6 +186,7 @@ public class Gb28181WhitelistHandlers {
     public String invitePlay(GatewayCommand cmd) {
         Map<String, Object> p = cmd.payload();
         return sender.deviceInvitePlay(cmd.deviceId(),
+                (String) p.get("channelId"),
                 (String) requireField(p, "mediaIp", cmd.type()),
                 ((Number) requireField(p, "mediaPort", cmd.type())).intValue(),
                 streamMode(p));

--- a/sip-gateway/pom.xml
+++ b/sip-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>sip-gateway</artifactId>

--- a/sip-gateway/sip-gateway-bom/pom.xml
+++ b/sip-gateway/sip-gateway-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>sip-gateway-bom</artifactId>

--- a/sip-gateway/sip-gateway-spring-boot-starter/pom.xml
+++ b/sip-gateway/sip-gateway-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>sip-gateway-spring-boot-starter</artifactId>

--- a/sip-gb28181/gb28181-client/pom.xml
+++ b/sip-gb28181/gb28181-client/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gb28181</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <artifactId>gb28181-client</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-client</name>

--- a/sip-gb28181/gb28181-client/src/main/java/io/github/lunasaw/gbproxy/client/transmit/cmd/ClientCommandSender.java
+++ b/sip-gb28181/gb28181-client/src/main/java/io/github/lunasaw/gbproxy/client/transmit/cmd/ClientCommandSender.java
@@ -2,7 +2,6 @@ package io.github.lunasaw.gbproxy.client.transmit.cmd;
 
 import com.luna.common.check.Assert;
 import com.luna.common.text.RandomStrUtil;
-import io.github.lunasaw.gb28181.common.entity.DeviceAlarm;
 import io.github.lunasaw.gb28181.common.entity.notify.*;
 import io.github.lunasaw.gb28181.common.entity.response.*;
 import io.github.lunasaw.gb28181.common.entity.enums.CmdTypeEnum;
@@ -82,18 +81,6 @@ public class ClientCommandSender implements ApplicationContextAware {
             .role("client").commandType(commandType)
             .fromDevice(from).toDevice(to).body(body)
             .errorEvent(errorEvent).okEvent(okEvent).build());
-    }
-
-    /**
-     * 发送设备告警命令（MESSAGE，body=DeviceAlarm）。
-     *
-     * @param from  本端设备
-     * @param to    目标平台
-     * @param alarm 告警信息
-     * @return 本次请求的 Call-ID
-     */
-    public static String sendAlarmCommand(FromDevice from, ToDevice to, DeviceAlarm alarm) {
-        return send("MESSAGE", from, to, alarm);
     }
 
     /**

--- a/sip-gb28181/gb28181-common/pom.xml
+++ b/sip-gb28181/gb28181-common/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gb28181</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <artifactId>gb28181-common</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-common</name>

--- a/sip-gb28181/gb28181-server/pom.xml
+++ b/sip-gb28181/gb28181-server/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gb28181</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <artifactId>gb28181-server</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-server</name>

--- a/sip-gb28181/gb28181-server/src/main/java/io/github/lunasaw/gbproxy/server/transmit/cmd/ServerCommandSender.java
+++ b/sip-gb28181/gb28181-server/src/main/java/io/github/lunasaw/gbproxy/server/transmit/cmd/ServerCommandSender.java
@@ -760,6 +760,48 @@ public class ServerCommandSender {
     }
 
     /**
+     * 发送实时点播 INVITE（s=Play），按 GB28181-2016 §9.2 标准寻址到<strong>通道</strong>。
+     *
+     * <p>与 {@link #deviceInvitePlay(String, String, Integer, StreamModeEnum)} 的区别：实时点播的目标是
+     * <strong>视频源（通道）</strong>，故 Request-URI / To 头 / SDP（o=/u=）/ Subject 第一段均用 channelId，
+     * 而信令<strong>传输地址</strong>仍取父设备注册的 ip:port（通道不独立注册）。这通过寻址 ID 与传输地址分离实现：
+     * {@code getToDevice(deviceId)} 取父设备传输地址，{@code to.setUserId(channelId)} 把寻址 ID 覆盖为通道。
+     *
+     * <p><strong>关于回显「污染」</strong>：设备 200 OK 会原样回显 To=channelId，框架
+     * {@code InviteResponseProcessor} 据此发出的 {@code Session.InviteOk} 事件 deviceId 字段即为 channelId。
+     * 这是标准报文的必然结果——业务层应以 <strong>Call-ID</strong> 关联会话、从自身会话上下文取设备/通道身份，
+     * 而非读该事件字段（见 voglander {@code Gb28181ProtocolHandler} 的 callId 查表实现）。
+     *
+     * <p>{@code channelId} 为空时退化为按设备点播（等价于上面的设备级重载），保持向后兼容。
+     *
+     * @param deviceId   父设备 ID（仅用于解析信令传输地址）
+     * @param channelId  通道国标编码（寻址：Request-URI/To/SDP/Subject）；为空则按设备点播
+     * @param sdpIp      收流 IP
+     * @param mediaPort  收��端口
+     * @param streamMode 流传输模式
+     * @return SIP Call-ID
+     */
+    public String deviceInvitePlay(String deviceId, String channelId, String sdpIp, Integer mediaPort, StreamModeEnum streamMode) {
+        if (channelId == null || channelId.isBlank()) {
+            return deviceInvitePlay(deviceId, sdpIp, mediaPort, streamMode);
+        }
+        // 寻址 ID 与传输地址分离（SIP AOR vs Contact）：
+        //   getToDevice(deviceId) —— 用父设备解析信令传输目的地（通道不独立注册，无自己的 ip:port）；
+        //   setUserId(channelId)  —— 把 Request-URI / To 头 user 部分覆盖为通道编码（GB28181 实时点播寻址视频源）。
+        // 报文实际发往父设备 ip:port，但逻辑寻址到通道，符合 GB28181-2016 §9.2 标准。
+        ToDevice to = getToDevice(deviceId);
+        to.setUserId(channelId);
+        to.setStreamMode(streamMode.name());
+        FromDevice from = deviceSupplier.getServerFromDevice();
+        // InviteRequest 用 channelId 构造 SDP：o=/u= 行与 Subject 第一段同样为通道编码。
+        InviteRequest req = new InviteRequest(channelId, streamMode, sdpIp, mediaPort);
+        return factory.getStrategy("server", "INVITE")
+            .execute(CommandContext.builder()
+                .role("server").commandType("INVITE")
+                .fromDevice(from).toDevice(to).content(req.getContent()).build());
+    }
+
+    /**
      * 发送历史回放 INVITE（s=Playback）。
      *
      * @param deviceId   目标设备 ID

--- a/sip-gb28181/pom.xml
+++ b/sip-gb28181/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>sip-gb28181</artifactId>

--- a/sip-test/gb28181-test/pom.xml
+++ b/sip-test/gb28181-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-test</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <version>${gb28181-proxy.version}</version>

--- a/sip-test/pom.xml
+++ b/sip-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
     </parent>
 
     <artifactId>sip-test</artifactId>


### PR DESCRIPTION
## Summary
- feat(gb28181-server): 实时点播 INVITE 标准寻址到通道(方案A)—— `ServerCommandSender` 新增按通道寻址逻辑,`Gb28181WhitelistHandlers` 补充对应处理
- refactor(gb28181-client): 移除 `ClientCommandSender` 中冗余的 `sendAlarmCommand(DeviceAlarm)` 重载
- chore(release): 版本号 1.8.1 → 1.8.2(全部 13 个 pom 统一升级,根 pom 属性同步)

## Commits
- `07512555` feat(gb28181-server): 实时点播 INVITE 标准寻址到通道(方案A)
- `1ad01b62` refactor(gb28181-client): 移除冗余的 sendAlarmCommand(DeviceAlarm) 重载
- `e5dbd118` chore(release): 版本号 1.8.1 → 1.8.2

## Test
- `mvn validate` 通过,多模块版本引用一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)