### PR TITLE
ci(release): master 自动按中央仓库已发布状态决定版本并发布

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,109 +1,84 @@
-name: Publish package to the Maven Central Repository and GitHub Packages
+name: Release to Maven Central and GitHub Packages
+
+# master 每次 push 即触发一次发布尝试:
+#   - 解析当前版本是否已发布到中央仓库;已发布则 patch+1 直到空位(见 scripts/resolve-release-version.sh)
+#   - 发布到 Maven 中央仓库(ossrh / central-publishing,waitUntil=published 阻塞到真正发布完成)
+#   - 若版本被 bump,则把新版本号 commit 回 master(带 [skip ci],避免触发自身)
+#   - 再发布到 GitHub Packages,并发布 Javadoc
 'on':
   push:
     branches:
       - master
+
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: write   # 版本 bump 后需 push 回 master
+      packages: write   # 发布到 GitHub Packages
     steps:
+      - uses: actions/checkout@v4
+        with:
+          # 用 PAT 以便对受保护分支有写权限;GITHUB_TOKEN 的 push 也不会再次触发本 workflow
+          token: ${{ secrets.SECRET_KEY }}
 
-      - uses: actions/checkout@v3
-      - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17 (with GPG key for Central signing)
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
-      - name: Publish to the Maven Central Repository
-        run: mvn -DskipTests --batch-mode deploy -Possrh
+
+      - name: Generate Maven settings.xml (ossrh + github_auth servers)
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'EOF'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>ossrh</id>
+                <username>${env.MAVEN_USERNAME}</username>
+                <password>${env.MAVEN_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github_auth</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Resolve next releasable version
+        id: ver
+        run: bash scripts/resolve-release-version.sh
+
+      - name: Publish to Maven Central
+        run: mvn -B -DskipTests -P ossrh deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE}}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Commit bumped version back to master
+        if: steps.ver.outputs.bumped == 'true'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -u
+          git commit -m "chore(release): 版本号自动递增至 ${{ steps.ver.outputs.version }} [skip ci]"
+          git push origin HEAD:master
 
-  github_publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-          server-id: github_auth
-      - name: Publish package
-        run: mvn -DskipTests --batch-mode deploy -P github_auth
+      - name: Publish to GitHub Packages
+        run: mvn -B -DskipTests -P github_auth deploy
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.SECRET_KEY }}
 
-      - name: Deploy JavaDoc 🚀
+      - name: Deploy JavaDoc
         uses: MathieuSoysal/Javadoc-publisher.yml@v2.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.SECRET_KEY }}
           javadoc-branch: javadoc
           java-version: 17
           target-folder: docs
-
-
-#  publish:
-#    # 任务运行的环境
-#    runs-on: ubuntu-latest
-#    # 任务的步骤
-#    steps:
-#      # 1. 声明 checkout 仓库代码到工作区
-#      - name: Checkout Git Repo
-#        uses: actions/checkout@v2
-#      # 2. 安装Java 环境 这里会用到的参数就是 Git Action secrets中配置的，
-#      #    取值要在key前面加  secrets.
-#      - name: Set up Maven Central Repo
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: 1.8
-#          server-id: ossrh
-#          server-username: ${{ secrets.OSSRH_USERNAME }}
-#          server-password: ${{ secrets.OSSRH_PASSWORD }}
-#          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-#      # 3. 发布到Maven中央仓库
-#      - name: Publish to Maven Central Repo
-#        # 这里用到了其他人写的action脚本，详细可以去看他的文档。
-#        run: mvn  -DskipTests  --batch-mode deploy -P ossrh
-#        uses: samuelmeuli/action-maven-publish@v1
-#        with:
-#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-#          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
-#          nexus_username: ${{ secrets.OSSRH_USER }}
-#          nexus_password: ${{ secrets.OSSRH_USERNAME }}
-
-
-
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '11'
-#          distribution: 'adopt'
-#      - name: Publish to GitHub Packages
-#        run: mvn  -DskipTests  --batch-mode deploy -P github_auth
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.SECRET_KEY }}
-
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/setup-java@v3
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#          server-id: github_auth
-#      - name: Publish package
-#        run: mvn -DskipTests --batch-mode deploy -P github_auth
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.SECRET_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -292,19 +292,14 @@
                     <url>https://maven.pkg.github.com/lunasaw/gb28181-proxy</url>
                 </snapshotRepository>
             </distributionManagement>
-            <repositories>
-                <repository>
-                    <!-- id需要与上面的server对应的id匹配 -->
-                    <id>github_auth</id>
-                    <name>GitHub OWNER Apache Maven Packages</name>
-                    <url>https://maven.pkg.github.com/lunasaw/gb28181-proxy</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
+            <!--
+                注意:此处不要再配 <repositories> 指向 GitHub Packages。
+                发布目标(distributionManagement)≠ 依赖来源(repositories)。
+                若把 GitHub Packages 也列为依赖来源,deploy 时 Maven 会去远程查找尚未发布的
+                io.github.lunasaw:sip-proxy:pom:${version},404 → "Could not find artifact ... in github_auth"。
+            -->
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
         </profile>
         <profile>

--- a/scripts/resolve-release-version.sh
+++ b/scripts/resolve-release-version.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# resolve-release-version.sh
+#
+# 解析"下一个可发布版本",供 CI 发布流程使用:
+#   1. 读取聚合根 pom 的当前 <version>;
+#   2. 若该版本已存在于 Maven 中央仓库,则 patch 段 +1,循环直到找到一个未被占用的版本;
+#   3. 若发生了版本变更,则把新版本写回整个 reactor
+#      (根 version、各模块 parent/自身 version,以及两个版本属性
+#       sip-proxy-common.version / gb28181-proxy.version)。
+#
+# 判定"是否已发布"以中央仓库实际产物为准(repo1.maven.org 上的 .pom 是否 200),
+# 这是 Sonatype Central 同步后的最终落地位置,也是同版本不可重复发布的事实边界。
+#
+# 输出:
+#   - stderr 打印过程日志;
+#   - stdout 打印 "VERSION=<resolved>" 与 "BUMPED=true|false";
+#   - 若存在 $GITHUB_OUTPUT,则追加 version=<resolved> / bumped=<bool> 供后续 step 引用。
+#
+# 注意:中央仓库同步有延迟(发布成功后 repo1 可能数十分钟才可见)。
+# 因此"刚发布后立刻再次 push"这一窗口内可能误判为未发布并触发重发,
+# 此时 Central Portal 会以 duplicate 拒绝——属可接受的边界情形。
+
+set -euo pipefail
+
+GROUP_PATH="io/github/lunasaw/sip-proxy"
+CENTRAL_BASE="https://repo1.maven.org/maven2/${GROUP_PATH}"
+HELP_PLUGIN="org.apache.maven.plugins:maven-help-plugin:3.4.0"
+
+log() { echo "$@" >&2; }
+
+current="$(mvn -q -N "${HELP_PLUGIN}:evaluate" -Dexpression=project.version -DforceStdout)"
+log "当前 pom 版本: ${current}"
+
+is_published() {
+  local v="$1" code
+  code="$(curl -s -o /dev/null -w '%{http_code}' "${CENTRAL_BASE}/${v}/sip-proxy-${v}.pom")"
+  [ "$code" = "200" ]
+}
+
+bump_patch() {
+  # 仅对 x.y.z 数值 patch 段 +1;若带 -SNAPSHOT/qualifier 则先剥离再 bump
+  local base="${1%%-*}" major minor patch
+  IFS='.' read -r major minor patch <<<"$base"
+  echo "${major}.${minor}.$((patch + 1))"
+}
+
+resolved="$current"
+bumped=false
+while is_published "$resolved"; do
+  log "版本 ${resolved} 已在中央仓库,递增 patch"
+  resolved="$(bump_patch "$resolved")"
+  bumped=true
+done
+log "解析结果: ${resolved} (bumped=${bumped})"
+
+if [ "$resolved" != "$current" ]; then
+  log "写回版本号到整个 reactor: ${current} -> ${resolved}"
+  mvn -q versions:set -DnewVersion="$resolved" -DprocessAllModules=true -DgenerateBackupPoms=false
+  mvn -q versions:set-property -Dproperty=sip-proxy-common.version -DnewVersion="$resolved" -DgenerateBackupPoms=false
+  mvn -q versions:set-property -Dproperty=gb28181-proxy.version  -DnewVersion="$resolved" -DgenerateBackupPoms=false
+fi
+
+echo "VERSION=${resolved}"
+echo "BUMPED=${bumped}"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "version=${resolved}"
+    echo "bumped=${bumped}"
+  } >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
- 新增 scripts/resolve-release-version.sh:查中央仓库判定当前版本是否已发布, 已发布则 patch+1 直到空位,并把新版本写回整个 reactor(根/各模块/两个版本属性)
- 重写 maven-publish.yml:单 job 串行 解析版本→发中央仓库→(bump 时)版本回写 master[skip ci] →发 GitHub Packages→发 Javadoc
- 修复 github_auth profile:移除误把 GitHub Packages 当依赖来源的 <repositories> (deploy 阶段会去远程找尚未发布的父 POM,导致 "Could not find artifact ... in github_auth")
- github_auth profile 默认不激活(activeByDefault=false),靠 workflow 显式 -P 激活
- maven-javadoc-plugin 关闭 detectLinks/detectOfflineLinks,消除模块间 package-list 缺失的报错噪音