### PR TITLE
fix(ci): 补回 gpg.passphrase server,修复签名 "No pinentry"

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -39,7 +39,7 @@ jobs:
           echo "pinentry-mode loopback"  >> ~/.gnupg/gpg.conf
           gpgconf --kill gpg-agent || true
 
-      - name: Generate Maven settings.xml (ossrh + github_auth servers)
+      - name: Generate Maven settings.xml (ossrh + github_auth + gpg passphrase)
         run: |
           mkdir -p ~/.m2
           cat > ~/.m2/settings.xml <<'EOF'
@@ -54,6 +54,16 @@ jobs:
                 <id>github_auth</id>
                 <username>${env.GITHUB_ACTOR}</username>
                 <password>${env.GITHUB_TOKEN}</password>
+              </server>
+              <!--
+                maven-gpg-plugin 默认 passphraseServerId=gpg.passphrase,从此 server 读签名口令。
+                旧 workflow 靠 setup-java 的 gpg-passphrase 输入自动注入此条目;
+                新 workflow 自管 settings.xml,必须显式补回,否则插件拿不到口令 →
+                回退 gpg-agent → 启动 pinentry → CI 无 pinentry → "gpg: signing failed: No pinentry"。
+              -->
+              <server>
+                <id>gpg.passphrase</id>
+                <passphrase>${env.MAVEN_GPG_PASSPHRASE}</passphrase>
               </server>
             </servers>
           </settings>


### PR DESCRIPTION
新 workflow 自管 settings.xml 时漏了 maven-gpg-plugin 默认读取的 gpg.passphrase server(旧版靠 setup-java 的 gpg-passphrase 输入自动注入)。 缺失导致插件拿不到口令→回退 gpg-agent→启动 pinentry→CI 无 pinentry→签名失败。 显式补回该 server,值取自环境变量 MAVEN_GPG_PASSPHRASE。