### PR TITLE
chore(version): 更新项目版本号从 1.8.3 到 1.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.lunasaw</groupId>
     <artifactId>sip-proxy</artifactId>
-    <version>1.8.3</version>
+    <version>1.8.4</version>
     <packaging>pom</packaging>
     <modules>
         <module>sip-common</module>
@@ -27,8 +27,8 @@
         <app.profiles>${project.name}</app.profiles>
         <sip.version>1.3.0-91</sip.version>
         <dom4j.version>2.1.4</dom4j.version>
-        <sip-proxy-common.version>1.8.3</sip-proxy-common.version>
-        <gb28181-proxy.version>1.8.3</gb28181-proxy.version>
+        <sip-proxy-common.version>1.8.4</sip-proxy-common.version>
+        <gb28181-proxy.version>1.8.4</gb28181-proxy.version>
         <skywalking.version>9.1.0</skywalking.version>
         <guava.version>32.1.3-jre</guava.version>
         <caffeine.version>3.1.8</caffeine.version>

--- a/sip-common/pom.xml
+++ b/sip-common/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <packaging>jar</packaging>
-    <version>1.8.3</version>
+    <version>1.8.4</version>
     <artifactId>sip-common</artifactId>
     <name>sip-common</name>
     <description>轻量级SIP框架封装</description>

--- a/sip-gateway/gateway-core/pom.xml
+++ b/sip-gateway/gateway-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>gateway-core</artifactId>

--- a/sip-gateway/gateway-gb28181/pom.xml
+++ b/sip-gateway/gateway-gb28181/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>gateway-gb28181</artifactId>

--- a/sip-gateway/pom.xml
+++ b/sip-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>sip-gateway</artifactId>

--- a/sip-gateway/sip-gateway-bom/pom.xml
+++ b/sip-gateway/sip-gateway-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>sip-gateway-bom</artifactId>

--- a/sip-gateway/sip-gateway-spring-boot-starter/pom.xml
+++ b/sip-gateway/sip-gateway-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gateway</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>sip-gateway-spring-boot-starter</artifactId>

--- a/sip-gb28181/gb28181-client/pom.xml
+++ b/sip-gb28181/gb28181-client/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gb28181</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
-    <version>1.8.3</version>
+    <version>1.8.4</version>
     <artifactId>gb28181-client</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-client</name>

--- a/sip-gb28181/gb28181-common/pom.xml
+++ b/sip-gb28181/gb28181-common/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gb28181</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
-    <version>1.8.3</version>
+    <version>1.8.4</version>
     <artifactId>gb28181-common</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-common</name>

--- a/sip-gb28181/gb28181-server/pom.xml
+++ b/sip-gb28181/gb28181-server/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-gb28181</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
-    <version>1.8.3</version>
+    <version>1.8.4</version>
     <artifactId>gb28181-server</artifactId>
     <packaging>jar</packaging>
     <name>gb28181-server</name>

--- a/sip-gb28181/pom.xml
+++ b/sip-gb28181/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>sip-gb28181</artifactId>

--- a/sip-test/gb28181-test/pom.xml
+++ b/sip-test/gb28181-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-test</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <version>${gb28181-proxy.version}</version>

--- a/sip-test/pom.xml
+++ b/sip-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lunasaw</groupId>
         <artifactId>sip-proxy</artifactId>
-        <version>1.8.3</version>
+        <version>1.8.4</version>
     </parent>
 
     <artifactId>sip-test</artifactId>


### PR DESCRIPTION
- 更新父项目的版本号到 1.8.4
- 更新 sip-common 模块的版本号到 1.8.4
- 更新 sip-gateway 相关模块的版本号到 1.8.4
- 更新 sip-gb28181 相关模块的版本号到 1.8.4
- 更新 sip-test 模块的版本号到 1.8.4
- 更新依赖管理中的版本变量到 1.8.4