### PR TITLE
ci(release): 发布流程拆成 central / github 两个串行 job

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,21 +1,29 @@
 name: Release to Maven Central and GitHub Packages
 
-# master 每次 push 即触发一次发布尝试:
-#   - 解析当前版本是否已发布到中央仓库;已发布则 patch+1 直到空位(见 scripts/resolve-release-version.sh)
-#   - 发布到 Maven 中央仓库(ossrh / central-publishing,waitUntil=published 阻塞到真正发布完成)
-#   - 若版本被 bump,则把新版本号 commit 回 master(带 [skip ci],避免触发自身)
-#   - 再发布到 GitHub Packages,并发布 Javadoc
+# master 每次 push 即触发一次发布尝试,拆成两个串行 job:
+#   central   —— 解析版本(已发布则 patch+1)、发布到 Maven 中央仓库、把 bump 后的版本 commit 回 master
+#   github    —— needs central;用 central 解析出的版本对齐工作区,发布到 GitHub Packages 并发布 Javadoc
+#
+# 拆分动机:职责清晰 + 失败隔离。central 的 central-publishing 插件 waitUntil=published 会长时间阻塞,
+# 与 GitHub Packages 发布混在一个 job 里时,日志交织、任一步失败都得整体重跑。拆开后 github job 可单独重跑。
+#
+# 跨 job 约束:GitHub Actions 不同 job 不共享文件系统,且 github job checkout 的是触发时的 SHA
+# (拿不到 central job bump 后 push 的 pom)。因此版本号通过 job output 传递,github job 在本地
+# 用 scripts/apply-release-version.sh 把工作区对齐到该版本,再发布。
 'on':
   push:
     branches:
       - master
 
 jobs:
-  release:
+  central:
+    name: Publish to Maven Central
     runs-on: ubuntu-latest
     permissions:
       contents: write   # 版本 bump 后需 push 回 master
-      packages: write   # 发布到 GitHub Packages
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      bumped: ${{ steps.ver.outputs.bumped }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +47,7 @@ jobs:
           echo "pinentry-mode loopback"  >> ~/.gnupg/gpg.conf
           gpgconf --kill gpg-agent || true
 
-      - name: Generate Maven settings.xml (ossrh + github_auth + gpg passphrase)
+      - name: Generate Maven settings.xml (ossrh + gpg passphrase)
         run: |
           mkdir -p ~/.m2
           cat > ~/.m2/settings.xml <<'EOF'
@@ -49,11 +57,6 @@ jobs:
                 <id>ossrh</id>
                 <username>${env.MAVEN_USERNAME}</username>
                 <password>${env.MAVEN_PASSWORD}</password>
-              </server>
-              <server>
-                <id>github_auth</id>
-                <username>${env.GITHUB_ACTOR}</username>
-                <password>${env.GITHUB_TOKEN}</password>
               </server>
               <!--
                 maven-gpg-plugin 默认 passphraseServerId=gpg.passphrase,从此 server 读签名口令。
@@ -88,6 +91,45 @@ jobs:
           git add -u
           git commit -m "chore(release): 版本号自动递增至 ${{ steps.ver.outputs.version }} [skip ci]"
           git push origin HEAD:master
+
+  github:
+    name: Publish to GitHub Packages
+    needs: central
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Javadoc-publisher 需 push 到 javadoc 分支
+      packages: write   # 发布到 GitHub Packages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SECRET_KEY }}
+
+      - name: Set up JDK 17
+        # 发 GitHub Packages 不签名(github_auth profile 无 GPG/source/javadoc 插件),故无需 GPG key
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Generate Maven settings.xml (github_auth)
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'EOF'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github_auth</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Align working tree to released version
+        # 不同 job 不共享文件系统,且本 job checkout 的是触发 SHA(拿不到 central job bump 后的 pom),
+        # 故用 central job 解析出的版本号在本地写回,确保发布的 GA 坐标与中央仓库一致。
+        run: bash scripts/apply-release-version.sh "${{ needs.central.outputs.version }}"
 
       - name: Publish to GitHub Packages
         run: mvn -B -DskipTests -P github_auth deploy

--- a/scripts/apply-release-version.sh
+++ b/scripts/apply-release-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# apply-release-version.sh <version>
+#
+# 把指定版本号写回整个 reactor:
+#   - 根 version、各模块 parent/自身 version(processAllModules);
+#   - 两个版本属性 sip-proxy-common.version / gb28181-proxy.version。
+#
+# 单点维护"版本写回"这件事,供两处复用:
+#   1. resolve-release-version.sh —— 解析出新版本后写回;
+#   2. CI 第二个发布 job(GitHub Packages)—— 用第一个 job 解析出的版本
+#      对齐自己工作区(不同 job 不共享文件系统,且 checkout 的是触发 SHA,
+#      拿不到第一个 job bump 后 push 的 pom)。
+
+set -euo pipefail
+
+target="${1:?usage: apply-release-version.sh <version>}"
+
+mvn -q versions:set -DnewVersion="$target" -DprocessAllModules=true -DgenerateBackupPoms=false
+mvn -q versions:set-property -Dproperty=sip-proxy-common.version -DnewVersion="$target" -DgenerateBackupPoms=false
+mvn -q versions:set-property -Dproperty=gb28181-proxy.version  -DnewVersion="$target" -DgenerateBackupPoms=false

--- a/scripts/resolve-release-version.sh
+++ b/scripts/resolve-release-version.sh
@@ -56,9 +56,7 @@ log "解析结果: ${resolved} (bumped=${bumped})"
 
 if [ "$resolved" != "$current" ]; then
   log "写回版本号到整个 reactor: ${current} -> ${resolved}"
-  mvn -q versions:set -DnewVersion="$resolved" -DprocessAllModules=true -DgenerateBackupPoms=false
-  mvn -q versions:set-property -Dproperty=sip-proxy-common.version -DnewVersion="$resolved" -DgenerateBackupPoms=false
-  mvn -q versions:set-property -Dproperty=gb28181-proxy.version  -DnewVersion="$resolved" -DgenerateBackupPoms=false
+  bash "$(dirname "$0")/apply-release-version.sh" "$resolved"
 fi
 
 echo "VERSION=${resolved}"


### PR DESCRIPTION
- central job:解析版本+发 Maven Central+bump 后 commit 回 master, 通过 job output 传出解析到的版本号
- github job(needs central):用该版本号本地对齐工作区后发 GitHub Packages + Javadoc;去掉 GPG step(github_auth profile 不签名)
- 抽出 scripts/apply-release-version.sh 单点维护"版本写回 reactor", resolve 脚本与 github job 共用,避免属性名漂移
- 动机:职责清晰 + 失败隔离,github job 可不重跑 Central 长阻塞单独重试